### PR TITLE
Added note about screen size to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # hebi-cad (cad.hebi.us)
-Public Repository for HEBI Robotics CAD files, drawings, and meshes
+Public Repository for HEBI Robotics CAD files, drawings, and meshes.
 
 > [!IMPORTANT] 
 > The CAD files in this Repository are stored using **Git LFS**. It is suggested to download files individually from the web as opposed to cloning the entire repo. If you choose to clone the entire repository, ensure you have Git LFS installed and initialized or the files will not properly checkout.
 
 ## Organization
-Each item has a folder with its part number and description.  In each folder you will find the 3D information for the part in the following file formats:
+Each item has a folder with its part number and description.  If you're on a narrow screen or window and don't see the files to the left in a sidebar, you can go to the files directly at:
+https://github.com/HebiRobotics/hebi-cad/
+
+In each folder you will find the 3D information for the part in the following file formats:
 
 ### Formats that preview natively in Github
 * PDF Drawing (if applicable)


### PR DESCRIPTION
Because of the way that we updated cad.hebi.us to point to the readme, the file list won't show up on smaller screens.  So I added a note to indicate that you can get to it with what is essentially the 'old' cad.hebi.us link.